### PR TITLE
Refactor: Centralize project directory management in agent state

### DIFF
--- a/agent/builder_graph.py
+++ b/agent/builder_graph.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import os
 
 import httpx
 import asyncio
@@ -32,6 +33,7 @@ SYSTEM_PROMPT_PATH = Path("./prompts/system_prompt.txt")
 class GraphProcessingState(BaseModel):
     messages: Annotated[list[BaseMessage], add_messages] = Field(default_factory=list)
     prompts: str = Field(default_factory=str, description="Prompts to be used by the agent")
+    project_dir: Path = Field(default_factory= lambda: Path(os.getcwd()))
 
 class AssistantAgent:
     def __init__(self, llm_provider:str, system_prompt_path: Path = SYSTEM_PROMPT_PATH):


### PR DESCRIPTION
## ♻️ Code Refactoring

### 📄 Description
Refactored the agent's state to include `project_dir` and updated `create_pr` and `analyze_file_changes` tools to utilize this new state variable.

### 🎯 Motivation
To centralize the management of the project directory within the agent's state, reducing redundancy and improving consistency across tools that require the repository's working directory. This also simplifies tool signatures by removing the need for a separate `working_directory` parameter.

### 🔧 Changes Made
- Added `project_dir: Path` to `GraphProcessingState` in `agent/builder_graph.py`.
- Modified `create_pr` tool in `agent/mcp_server.py` to use `state.get("project_dir")` instead of `working_directory`.
- Modified `analyze_file_changes` tool in `agent/mcp_server.py` to use `state.get("project_dir")` instead of `working_directory`.

### ✅ Testing Checklist
- [ ] All existing unit and integration tests pass
- [ ] Verified that there are no functional or behavioral changes
- [ ] Assessed for performance regressions or improvements

### ⚠️ Risk Assessment
Low risk. Changes are primarily refactoring of how the working directory is accessed. Existing tests should cover the functionality of `create_pr` and `analyze_file_changes`.